### PR TITLE
Table padding edit

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -428,7 +428,7 @@ body {
 .markdown-rendered table td,
 .markdown-rendered .table-view-table th,
 .markdown-rendered .table-view-table td {
-  padding: 4px 8px 4px 16px;
+  padding: 6px 18px 6px 18px;
 }
 .cm-embed-block.markdown-rendered .block-language-dataview td,
 .markdown-rendered table td,


### PR DESCRIPTION
## Describe your pull request

The padding of the first iteration of centered tables was bad (and text was off-center), this one improves readability.

My vault outline as an example:
![image](https://user-images.githubusercontent.com/80261260/226948660-e5d286fc-dcde-4596-bf4f-c147c9d0f06d.png)

