### PR TITLE
Fix background color for titlebar buttons on Windows

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -473,6 +473,11 @@ body {
   margin-top: 0;
 }
 
+/* FIX: background color for titlebar buttons on Windows */
+div.titlebar-button-container.mod-right {
+  background-color: var(--background-primary) !important;
+}
+
 /* EDITOR: font-scalable edit-block-button */
 /* add header padding for button if last column is right-aligned */
 .markdown-source-view table th:last-child[align="right"] {


### PR DESCRIPTION
This PR fixes the background color for titlebar buttons on Windows and addresses https://github.com/crashmoney/obsidian-typewriter/issues/37

It seems that this bug only affects the theme when running in dark mode.


Before:
![before](https://github.com/crashmoney/obsidian-typewriter/assets/32670283/2f81c3af-8c10-4add-84ed-6de1097e3b4f)


After (Dark):
![fixed_dark](https://github.com/crashmoney/obsidian-typewriter/assets/32670283/bbc16ed5-cb23-4d98-9b40-1e671bec7b8f)


After (Light):
![fixed_light](https://github.com/crashmoney/obsidian-typewriter/assets/32670283/ae75b16d-612f-4479-8478-401a2dea51d8)

