### PR TITLE
make theme accent selectable via Style Setting

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -82,11 +82,11 @@ body {
   --base-d: 15%; /* base lightness for dark mode. 0 is black */
   --base-l: 96%; /* base lightness for light mode. 100 is white */
 
-  /* rgb: 81, 157, 92 */
-  --theme-accent-h: 129;
-  --theme-accent-s: 31.9%;
-  --theme-accent-l: 46.7%;
-  --theme-accent-d: 46.7%;
+  /* Get accent from Style settings, defaults to rgb: 81, 157, 92 for both dark and light themes */
+  --theme-accent-h: var(--theme-accent-sel-h, 129);
+  --theme-accent-s: var(--theme-accent-sel-s, 31.9%);
+  --theme-accent-l: var(--theme-accent-sel-l, 46.7%);
+  --theme-accent-d: var(--theme-accent-sel-d, 46.7%);
 
   /* WIP - working with relative HSL values
   --theme-accent-h: calc(var(--accent-h) - 125);
@@ -591,6 +591,18 @@ settings:
         title: Highlight the active line
         type: class-toggle
         default: on
+    -
+        id: theme-accent-sel
+        title: Theme accent
+        type: variable-themed-color
+        opacity: false
+        format: hex
+        alt-format:
+            -
+                id: theme-accent-sel
+                format: hsl-split
+        default-light: '#519D5C'
+        default-dark: '#519D5C'
 
 */
 


### PR DESCRIPTION
## Describe your pull request

Add a [Style Setting](https://github.com/obsidian-community/obsidian-style-settings) option to pick the theme accent. This theme is green-ish and hard-coded within the theme-accent variable. I modified slightly so that a color picker (for both black and light themes) allows to set this color. If not set, it defaults to the same green-ish color.



